### PR TITLE
Enable test with Unity CI

### DIFF
--- a/.github/workflows/check_test.yml
+++ b/.github/workflows/check_test.yml
@@ -1,0 +1,45 @@
+name: Check Tests
+
+on: [push, pull_request]
+
+jobs:
+  buildAndTestForLinuxBasedPlatforms:
+    name: Build for ${{ matrix.targetPlatform }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        projectPath:
+          - ./
+        unityVersion:
+          - 6000.0.24f1
+        targetPlatform:
+          - Android
+    steps:
+      # Checkout the code
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      # Cache Unity Library
+      - uses: actions/cache@v3
+        with:
+          path: ${{ matrix.projectPath }}/Library
+          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-${{ hashFiles(matrix.projectPath) }}
+          restore-keys: |
+            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
+            Library-${{ matrix.projectPath }}-
+            Library-
+
+      # Step 1: Run Unity Tests
+      - uses: game-ci/unity-test-runner@v4
+        id: testRunner
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          githubToken: ${{ secrets.GITHUB_TOKEN  }}

--- a/Assets/Scripts/Game/Tests/E2ETest/Levels/LevelsTests.cs
+++ b/Assets/Scripts/Game/Tests/E2ETest/Levels/LevelsTests.cs
@@ -105,13 +105,13 @@ namespace Game.Tests.E2ETest.Levels
             GetInstance<IRoundService>().SetRound(level);
             GetInstance<IRoundService>().EndRound(false);
             
-            yield return new WaitForSeconds(2.0f);
+            yield return new WaitForSeconds(4.50f);
             var startRound = GetInstance<IRoundService>().GetRound();
             
             var play = GameObject.Find(PLAY_BUTTON_OBJECT);
             yield return PerformDrag(play.transform.position, play.transform.position + Vector3.down, 0.25f, RenderMode.ScreenSpaceCamera);
 
-            yield return new WaitForSeconds(5.0f);
+            yield return new WaitForSeconds(7.25f);
             var cardGrid = GameObject.Find(CARD_GRID_OBJECT);
             var cards = cardGrid.GetComponentsInChildren<CardView>();
             
@@ -123,10 +123,10 @@ namespace Game.Tests.E2ETest.Levels
                 foreach (var card in pair)
                 {
                     yield return PerformDrag(card.transform.position, card.transform.position + Vector3.down, 0.25f, RenderMode.ScreenSpaceCamera);
-                    yield return new WaitForSeconds(0.25f);
+                    yield return new WaitForSeconds(0.75f);
                 }
             }
-            yield return new WaitForSeconds(1.0f);
+            yield return new WaitForSeconds(2.0f);
 
             var endRound = GetInstance<IRoundService>().GetRound();
             Assert.AreEqual(startRound + 1, endRound);


### PR DESCRIPTION
This pull request includes a new GitHub Actions workflow to automate testing and several adjustments to the wait times in the `EvaluateLevel` test method to improve its reliability.

### New GitHub Actions Workflow:

* [`.github/workflows/check_test.yml`](diffhunk://#diff-93e221bd1a176d6f75e8ce73c606a9207833c87eb4978bae6f92fc7ee2029215R1-R45): Added a new workflow configuration to run tests on push and pull request events. This workflow includes steps for checking out the code, caching the Unity Library, and running Unity tests using the `game-ci/unity-test-runner` action.

### Test Adjustments:

* `Assets/Scripts/Game/Tests/E2ETest/Levels/LevelsTests.cs`: Increased the wait times in the `EvaluateLevel` method to ensure more reliable test execution. Changes include:
  - Increased wait time after ending the round from 2.0 seconds to 4.5 seconds.
  - Increased wait time after performing a drag action from 5.0 seconds to 7.25 seconds.
  - Increased wait time between card drags from 0.25 seconds to 0.75 seconds.
  - Increased final wait time before asserting the round from 1.0 second to 2.0 seconds.